### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,4 +36,4 @@ Installing from PyPI
 
 ``pip install buildnotify --pre``
 
-Launch using ``./venv/bin/buildnotifyapplet.py``
+Launch using ``.local/bin/buildnotifyapplet.py``


### PR DESCRIPTION
Fix path to buildnotify after installing it via pip (at least on my system)